### PR TITLE
fix: protocol detection: use http when file://

### DIFF
--- a/src/media.vimeo.js
+++ b/src/media.vimeo.js
@@ -58,7 +58,8 @@ videojs.Vimeo = videojs.MediaTechController.extend({
 
     this.player_el_.insertBefore(this.el_, this.player_el_.firstChild);
 
-    this.baseUrl = document.location.protocol + '//player.vimeo.com/video/';
+    var protocol = (document.location.protocol === 'file:')?'http:': document.location.protocol;
+    this.baseUrl = protocol + '//player.vimeo.com/video/';
 
     this.vimeo = {};
     this.vimeoInfo = {};


### PR DESCRIPTION
Fix when using from a file:// url, the vimeo player couldnt be loaded.