### PR TITLE
Fix the onLoad event listener for the player Iframe on IE8

### DIFF
--- a/src/media.vimeo.js
+++ b/src/media.vimeo.js
@@ -57,7 +57,12 @@ videojs.Vimeo = videojs.MediaTechController.extend({
     this.vimeoInfo = {};
 
     var self = this;
-    this.el_.onload = function() { self.onLoad(); };
+    if ( this.el_.attachEvent ) { //Fix for the onLoad event listener on IE8
+      this.el_.attachEvent( 'onload', vjs.bind( self, self.onLoad ) );
+    }
+    else {
+      this.el_.onload = function() { self.onLoad(); };
+    }
 
     this.startMuted = player.options()['muted'];
 


### PR DESCRIPTION
The ``onLoad`` event for the video iframe was never triggered on IE8, therefore the ``player.tech.vimeo.api`` was never set and the player was unresponsive.
To fix this, we need to set the listener using the ``attachEvent`` method.

More information about this issue:
http://stackoverflow.com/questions/6455834/iframe-onload-in-ie7-8-with-javascript
http://stackoverflow.com/questions/12910534/why-doesnt-ie8-handle-iframe-onload-events
http://stackoverflow.com/questions/18512112/ie8-iframe-onload-not-firing