### PR TITLE
emit seeking event per vjs spec

### DIFF
--- a/src/media.vimeo.js
+++ b/src/media.vimeo.js
@@ -220,6 +220,7 @@ videojs.Vimeo.prototype.onFinish = function(){
 };
 
 videojs.Vimeo.prototype.onSeek = function(data){
+  this.player_.trigger('seeking');
   this.vimeoInfo.time = data.seconds;
   this.player_.trigger('timeupdate');
   this.player_.trigger('seeked');


### PR DESCRIPTION
The videojs Player API docs specify a 'seeking' event, to be emitted when the user begins a seek, before the video is updated to the sought location. This PR just adds that event at the beginning of the 'onSeek' method.