### PR TITLE
Changed bower name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "colearnr/videojs-vimeo",
+  "name": "videojs-vimeo",
   "version": "1.0.1",
   "main": ["vjs.vimeo.js"],
   "description": "Allows you to use Vimeo URL as source with Video.js.",


### PR DESCRIPTION
The name /colearnr/videojs-vimeo cause a ENOTFOUND when bower install is called. please fix it